### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 db.sqlite3
+Pipfile.lock

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,5 @@ verify_ssl = true
 
 [packages]
 django = ">=2.2.2"
-cantera = "*"
-
-[requires]
-python_version = "3.6"
+numpy = ">=1.14"
+ruamel-yaml = ">=0.15.97"

--- a/README.md
+++ b/README.md
@@ -1,18 +1,26 @@
 # ChemCheck
-A tool to check chemistry, in the form of chemkin and cantera files.
 
+A tool to check chemistry, in the form of CHEMKIN and Cantera files.
 
-Initial setup, installing dependencies (or use the Pipfile):
+Initial setup, installing dependencies using conda:
 
-    $ conda install django sqlparse ruamel_yaml
+    $ conda create -n chemcheck -c conda-forge django\>=2.2.2 ruamel.yaml numpy
+    $ conda activate chemcheck
+    $ cd ChemCheck
 
-First run or every time someone changes your Models:
+Initial setup, installing dependencies using `pipenv`:
+
+    $ pipenv install
+    $ pipenv shell
+    $ cd ChemCheck
+
+First run or every time someone changes the models:
 
     $ python3 manage.py makemigrations
     $ python3 manage.py migrate
 
 To launch the server:
 
-    $ python3 manag.py runserver
+    $ python3 manage.py runserver
 
 then point a browser at http://127.0.0.1:8000/upload/


### PR DESCRIPTION
This pull request updates the dependencies in the Pipfile for pipenv. In addition, with conda the only way to satisfy the dependency implied by the Pipfile that Django be >=2.2.2 is to use the conda-forge channel.