### PR TITLE
Logging messages are rendered

### DIFF
--- a/ChemCheck/upload/ck2yaml.py
+++ b/ChemCheck/upload/ck2yaml.py
@@ -1923,10 +1923,12 @@ class Parser:
                      quiet=False, permissive=None):
 
         parser = Parser()
+        f = os.path.split(input_file)[0]
+        p = os.path.join(f, "error.txt")
         if quiet:
             logging.basicConfig(level=logging.ERROR)
         else:
-            logging.basicConfig(level=logging.INFO)
+            logging.basicConfig(filename=p, level=logging.INFO)
 
         if permissive is not None:
             parser.warning_as_error = not permissive

--- a/ChemCheck/upload/ck2yaml.py
+++ b/ChemCheck/upload/ck2yaml.py
@@ -1925,6 +1925,8 @@ class Parser:
         parser = Parser()
         f = os.path.split(input_file)[0]
         p = os.path.join(f, "error.txt")
+        if not p:
+            open(p, "w")
         if quiet:
             logging.basicConfig(level=logging.ERROR)
         else:

--- a/ChemCheck/upload/ck2yaml.py
+++ b/ChemCheck/upload/ck2yaml.py
@@ -1925,8 +1925,6 @@ class Parser:
         parser = Parser()
         f = os.path.split(input_file)[0]
         p = os.path.join(f, "error.txt")
-        if not p:
-            open(p, "w")
         if quiet:
             logging.basicConfig(level=logging.ERROR)
         else:

--- a/ChemCheck/upload/templates/ck2yaml.html
+++ b/ChemCheck/upload/templates/ck2yaml.html
@@ -3,8 +3,6 @@
 {% block content %}
 <h1>Mechanism {{ mech.id }} conversion to yaml</h1>
 
-{{ content }}
-
 {{ conversion_log }}
 
 {% if mech.ct_mechanism_file %}

--- a/ChemCheck/upload/templates/ck2yaml.html
+++ b/ChemCheck/upload/templates/ck2yaml.html
@@ -3,6 +3,8 @@
 {% block content %}
 <h1>Mechanism {{ mech.id }} conversion to yaml</h1>
 
+{{ content }}
+
 {{ conversion_log }}
 
 {% if mech.ct_mechanism_file %}

--- a/ChemCheck/upload/views.py
+++ b/ChemCheck/upload/views.py
@@ -7,6 +7,7 @@ from django.core.files.storage import FileSystemStorage
 import os
 from django.core.files.base import File
 from django.urls import reverse_lazy
+from .ck2yaml import strip_nonascii
 
 
 # Create your views here.
@@ -97,7 +98,7 @@ def ace(request, pk, filetype):
     f = f.path
 
     filename = os.path.split(f)[-1]
-    content = open(f, "r").read()
+    content = strip_nonascii(open(f, 'r', errors='ignore').read())
     return render(request, 'ace.html', {
         'content': content,
         'mechanism': mechanism,

--- a/ChemCheck/upload/views.py
+++ b/ChemCheck/upload/views.py
@@ -58,12 +58,14 @@ def ck2yaml(request, pk):
     except Exception as e:
         error = os.path.join(os.path.split(input_file)[0], 'error.txt')
         content = open(error, "r").read()
+        conversion_log += str(content)
         conversion_log += str(e)                      
         error_message = traceback.format_exc()
         conversion_log += error_message
         mechanism.ct_conversion_errors = error_message
         mechanism.ct_mechanism_file = None
         mechanism.save()
+        open (error, "w").close()
     else:
         mechanism.ct_mechanism_file = out_name
         mechanism.save()
@@ -71,7 +73,6 @@ def ck2yaml(request, pk):
     return render(request, 'ck2yaml.html', {
        'mech': mechanism,
        'conversion_log': conversion_log,
-       'content': content,
     })
 
     

--- a/ChemCheck/upload/views.py
+++ b/ChemCheck/upload/views.py
@@ -30,7 +30,7 @@ def upload(request):
 def ck2yaml(request, pk):
     mechanism = get_object_or_404(Mechanism, pk=pk)
 
-    conversion_log = "Going to try this..."
+    conversion_log = "Going to try this...\n"
 
     from .ck2yaml import Parser
     import traceback
@@ -56,6 +56,8 @@ def ck2yaml(request, pk):
                         permissive = True,
                         )
     except Exception as e:
+        error = os.path.join(os.path.split(input_file)[0], 'error.txt')
+        content = open(error, "r").read()
         conversion_log += str(e)                      
         error_message = traceback.format_exc()
         conversion_log += error_message
@@ -69,6 +71,7 @@ def ck2yaml(request, pk):
     return render(request, 'ck2yaml.html', {
        'mech': mechanism,
        'conversion_log': conversion_log,
+       'content': content,
     })
 
     
@@ -202,10 +205,8 @@ class MechanismUpdateView(MechanismObjectMixin, View):
 
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
-
         form = ChemkinUpload(request.POST, request.FILES, instance=obj)
         if form.is_valid():
             form.save()
             url = reverse_lazy('mechanism-detail', args=[obj.pk])
             return HttpResponseRedirect(url)
-    

--- a/ChemCheck/upload/views.py
+++ b/ChemCheck/upload/views.py
@@ -58,7 +58,8 @@ def ck2yaml(request, pk):
                         )
     except Exception as e:
         error = os.path.join(os.path.split(input_file)[0], 'error.txt')
-        content = open(error, "r").read()
+        with open(error, "r") as err:
+            content = err.read()
         conversion_log += str(content)
         conversion_log += str(e)                      
         error_message = traceback.format_exc()

--- a/ChemCheck/upload/views.py
+++ b/ChemCheck/upload/views.py
@@ -98,7 +98,8 @@ def ace(request, pk, filetype):
     f = f.path
 
     filename = os.path.split(f)[-1]
-    content = strip_nonascii(open(f, 'r', errors='ignore').read())
+    with open(f, 'r', errors='ignore') as file_content:
+        content = strip_nonascii(file_content.read())
     return render(request, 'ace.html', {
         'content': content,
         'mechanism': mechanism,

--- a/ChemCheck/upload/views.py
+++ b/ChemCheck/upload/views.py
@@ -37,14 +37,16 @@ def ck2yaml(request, pk):
     import traceback
     import logging
 
-    parser = Parser()
+
     input_file = mechanism.ck_mechanism_file.path
     thermo_file =  mechanism.ck_thermo_file.path if mechanism.ck_thermo_file else None
     transport_file = mechanism.ck_transport_file.path if mechanism.ck_transport_file else None
     surface_file = mechanism.ck_surface_file.path if mechanism.ck_surface_file else None
     phase_name = None # will default to 'gas'
     out_name = os.path.join(os.path.split(input_file)[0], 'cantera.txt')
-
+    error_filename = os.path.join(os.path.split(input_file)[0], 'error.txt')
+    open(error_filename, "w").close() # wipes the file it already existed.
+    parser = Parser()
 
     try:
         parser.convert_mech(input_file, 
@@ -57,8 +59,8 @@ def ck2yaml(request, pk):
                         permissive = True,
                         )
     except Exception as e:
-        error = os.path.join(os.path.split(input_file)[0], 'error.txt')
-        with open(error, "r") as err:
+        
+        with open(error_filename, "r") as err:
             content = err.read()
         conversion_log += str(content)
         conversion_log += str(e)                      
@@ -67,7 +69,7 @@ def ck2yaml(request, pk):
         mechanism.ct_conversion_errors = error_message
         mechanism.ct_mechanism_file = None
         mechanism.save()
-        open (error, "w").close()
+        
     else:
         mechanism.ct_mechanism_file = out_name
         mechanism.save()


### PR DESCRIPTION
Logging messages were saved into a file, and the file content was rendered on the website. However, logging messages were written in the file after every convertion, so the logging messages were duplicated with hitting "convert to yaml" button more than one time.